### PR TITLE
Implement Site session management

### DIFF
--- a/app/assets/stylesheets/module-admin.scss
+++ b/app/assets/stylesheets/module-admin.scss
@@ -4,7 +4,7 @@ header.main, menu.main {
 	a {
 		color: darken($color_logo_yellow, 20%);
 	}
-	a:hover, a.pure-menu-link:hover {
+	a:hover, a.pure-menu-link:hover, input.pure-menu-link:hover {
 		background: lighten($color_logo_yellow, 35%);
 	}
 }
@@ -43,6 +43,25 @@ header.main {
 	.pure-menu-link:hover {
 		background: initial;
 	}
+
+  input.pure-menu-link {
+    display: block;
+    width: 100%;
+    text-align: left;
+    border-radius: 0;
+    text-transform: none;
+    color: #946b04;
+    background: inherit;
+    font-size: inherit;
+    padding: .8em 1.5em;
+    margin: 0;
+    height: auto;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
 	.logo {
 		height: 26px;
 		overflow: hidden;

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,59 +1,12 @@
 class Admin::BaseController < ApplicationController
-  before_action :authenticate_admin!, :set_current_site
+  include SessionHelper
+  include SiteSessionHelper
 
-  helper_method :current_admin, :current_site, :admin_signed_in?
+  before_action :authenticate_admin!
+
+  helper_method :current_admin, :admin_signed_in?
+  helper_method :current_site, :managing_site?
+  helper_method :managed_sites
 
   layout "admin/application"
-
-  private
-
-  def current_admin
-    @current_admin ||= find_current_admin
-  end
-
-  def current_site
-    @site = params[:site_name]
-  end
-
-  def admin_signed_in?
-    current_admin.present?
-  end
-
-  def sign_in_admin(admin_id)
-    session[:admin_id] = admin_id
-  end
-
-  def sign_out_admin
-    @current_admin = session[:admin_id] = nil
-  end
-
-  def authenticate_admin!
-    raise_admin_not_signed_in unless admin_signed_in?
-  end
-
-  def find_current_admin
-    Admin.confirmed.find_by(id: session[:admin_id])
-  end
-
-  def after_sign_in_path
-    admin_root_path
-  end
-
-  def after_sign_out_path
-    admin_root_path
-  end
-
-  def raise_admin_not_signed_in
-    redirect_to(
-      new_admin_sessions_path,
-      alert: "We need you to sign in to continue." # TODO. Missing localization.
-    )
-  end
-
-  def raise_admin_not_authorized
-    redirect_to(
-      request.referrer || admin_root_path,
-      alert: "You are not authorized to perform this action." # TODO. Missing localization.
-    )
-  end
 end

--- a/app/controllers/admin/sites/sessions_controller.rb
+++ b/app/controllers/admin/sites/sessions_controller.rb
@@ -1,0 +1,15 @@
+class Admin::Sites::SessionsController < Admin::BaseController
+  def create
+    if allowed_site?(params[:site_id])
+      enter_site(params[:site_id])
+      redirect_to(request.referrer)
+    else
+      raise_admin_not_authorized
+    end
+  end
+
+  def destroy
+    leave_site
+    redirect_to(request.referrer)
+  end
+end

--- a/app/controllers/concerns/admin/session_helper.rb
+++ b/app/controllers/concerns/admin/session_helper.rb
@@ -1,0 +1,51 @@
+module Admin::SessionHelper
+  extend ActiveSupport::Concern
+
+  private
+
+  def current_admin
+    @current_admin ||= find_current_admin
+  end
+
+  def admin_signed_in?
+    current_admin.present?
+  end
+
+  def sign_in_admin(admin_id)
+    session[:admin_id] = admin_id
+  end
+
+  def sign_out_admin
+    @current_admin = session[:admin_id] = nil
+  end
+
+  def authenticate_admin!
+    raise_admin_not_signed_in unless admin_signed_in?
+  end
+
+  def find_current_admin
+    Admin.confirmed.find_by(id: session[:admin_id])
+  end
+
+  def after_sign_in_path
+    admin_root_path
+  end
+
+  def after_sign_out_path
+    admin_root_path
+  end
+
+  def raise_admin_not_signed_in
+    redirect_to(
+      new_admin_sessions_path,
+      alert: "We need you to sign in to continue."
+    )
+  end
+
+  def raise_admin_not_authorized
+    redirect_to(
+      request.referrer || admin_root_path,
+      alert: "You are not authorized to perform this action."
+    )
+  end
+end

--- a/app/controllers/concerns/admin/site_session_helper.rb
+++ b/app/controllers/concerns/admin/site_session_helper.rb
@@ -1,0 +1,29 @@
+module Admin::SiteSessionHelper
+  extend ActiveSupport::Concern
+
+  private
+
+  def current_site
+    @current_site ||= Site.find_by(id: session[:site_id]) if session[:site_id]
+  end
+
+  def managing_site?
+    current_site.present?
+  end
+
+  def leave_site
+    @current_site = session[:site_id] = nil
+  end
+
+  def enter_site(site_id)
+    session[:site_id] = site_id
+  end
+
+  def managed_sites
+    @managed_sites ||= current_admin.sites
+  end
+
+  def allowed_site?(site_id)
+    site_id.to_i.in?(managed_sites.map(&:id))
+  end
+end

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -9,4 +9,10 @@ class Admin < ApplicationRecord
     format: { with: EMAIL_ADDRESS_REGEXP }
 
   enum authorization_level: { regular: 0, manager: 1 }
+
+  def sites
+    # FIXME. That's a fake association.
+
+    Site.all
+  end
 end

--- a/app/views/admin/sessions/_form.html.erb
+++ b/app/views/admin/sessions/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for :session, url: admin_sessions_path do |f| %>
+<%= form_for :session, url: admin_sessions_path, html: { id: 'admin-session-form' } do |f| %>
   <div class="form_item input_text">
     <%= f.label :email %>
     <%= f.email_field :email, autofocus: true %>

--- a/app/views/layouts/admin/application.html.erb
+++ b/app/views/layouts/admin/application.html.erb
@@ -23,19 +23,29 @@
       <ul class="pure-menu-list">
         <li class="pure-menu-item pure-menu-has-children pure-menu-allow-hover">
           <a href="#" id="menuLink1" class="pure-menu-link">Red</a>
-          <ul class="pure-menu-children">
-            <li class="pure-menu-item"><a href="#" class="pure-menu-link">Ayuntamiento de Burjassot</a></li>
-            <li class="pure-menu-item"><a href="#" class="pure-menu-link">Ayuntamiento de Alzira</a></li>
-            <li class="pure-menu-item"><a href="#" class="pure-menu-link">Ayuntamiento de Valencia</a></li>
-            <li class="pure-menu-item"><a href="admin_sites" class="pure-menu-link">Administrar</a></li>
+          <ul id="managed-sites-list" class="pure-menu-children">
+            <% managed_sites.each do |site| %>
+              <li class="pure-menu-item">
+                <%= button_to(
+                  site.name,
+                  admin_sites_sessions_path,
+                  params: { site_id: site.id },
+                  class: "pure-menu-link") %>
+              </li>
+            <% end %>
+            <li class="pure-menu-item">
+              <a href="admin_sites" class="pure-menu-link">Administrar</a>
+            </li>
           </ul>
         </li>
       </ul>
     </div>
 
-    <div class="pure-menu-link">
-      Ayuntamiento de Burjassot
-    </div>
+    <% if managing_site? %>
+      <div id="current-site-name" class="pure-menu-link">
+        <%= current_site.name %>
+      </div>
+    <% end %>
 
     <% if admin_signed_in? %>
       <div class="right pure-menu pure-menu-horizontal">
@@ -60,7 +70,7 @@
         </ul>
       </div>
     <% end %>
-    
+
     <div class="right pure-menu-link">
       Notificaciones
     </div>
@@ -68,9 +78,6 @@
     <div class="right pure-menu-link">
       Ver site
     </div>
-
-  </div>
-  
 
 </header>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,10 @@ Rails.application.routes.draw do
     get '/' => 'welcome#index', as: :root
 
     resource :sessions, only: [:new, :create, :destroy]
+
+    namespace :sites do
+      resource :sessions, only: [:create, :destroy]
+    end
   end
 
   localized do

--- a/test/integration/admin/site_session_test.rb
+++ b/test/integration/admin/site_session_test.rb
@@ -1,0 +1,30 @@
+require "test_helper"
+
+class Admin::SiteSessionTest < ActionDispatch::IntegrationTest
+  def setup
+    super
+    @path = admin_root_path
+  end
+
+  def admin
+    @admin ||= admins(:tony)
+  end
+
+  def site
+    @site ||= sites(:acme)
+  end
+
+  def test_site_switch
+    with_signed_in_admin(admin) do
+      visit @path
+
+      within "#managed-sites-list" do
+        click_on site.name
+      end
+
+      within "#current-site-name" do
+        assert has_content?(site.name)
+      end
+    end
+  end
+end

--- a/test/support/authentication_helper.rb
+++ b/test/support/authentication_helper.rb
@@ -1,0 +1,23 @@
+module AuthenticationHelper
+  def with_signed_in_admin(admin)
+    sign_in_admin(admin)
+    yield
+    sign_out_admin
+  end
+
+  private
+
+  def sign_in_admin(admin)
+    visit new_admin_sessions_path
+
+    within("#admin-session-form") do
+      fill_in :session_email, with: admin.email
+      fill_in :session_password, with: "gobierto"
+      click_on "Log in"
+    end
+  end
+
+  def sign_out_admin
+    within("header") { click_link "Sign out" }
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -36,8 +36,10 @@ end
 class ActionDispatch::IntegrationTest
   require "minitest/rails/capybara"
   require "capybara/poltergeist"
+  require "support/authentication_helper"
 
   include Capybara::DSL
+  include AuthenticationHelper
 
   Capybara.register_driver :poltergeist_custom do |app|
     Capybara::Poltergeist::Driver.new(


### PR DESCRIPTION
This PR implements #17.

### What does this PR do?

This PR implements Site Session management and switching under the Admin namespace.

- Minor stylesheet adjustments.
- Partially integrate admin front-end.
- Refactor `Admin::BaseController` by extracting groups of methods into modules.

### How should this be manually tested?

Switch between any managed Sites and see how the context changes according to `current_site`.